### PR TITLE
docs: switch README banner to PNG asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mini SCADA HMI Dashboard
 
 <p align="center">
-  <img src="docs/banner.png" alt="Mini SCADA HMI Dashboard" width="600">
+  <img src=".github/assets/mini-scada-hmi-banner.png" alt="Mini SCADA HMI Dashboard" width="600">
 </p>
 
 <h1 align="center">🏭 Mini SCADA HMI Dashboard</h1>


### PR DESCRIPTION
Switch banner reference from docs/banner.png to .github/assets/mini-scada-hmi-banner.png